### PR TITLE
Experiment to add modified date to README

### DIFF
--- a/.github/generate.py
+++ b/.github/generate.py
@@ -2,6 +2,8 @@
 
 import os
 import json
+import subprocess
+from datetime import datetime
 from urllib.parse import quote as _quote
 
 from string import Template
@@ -113,10 +115,16 @@ def generate_item(theme: str) -> str:
 
     release_url = f"release/{urlencode(theme)}.zip?raw=true"
 
+    git_result = subprocess.run(
+        ["git", "log", "-1", "--pretty=%cI", "--", dir_path],
+        stdout=subprocess.PIPE)
+    updated = datetime.fromisoformat(git_result.stdout.decode('utf-8').strip())
+
     item = {
         "NAME": name,
         "AUTHOR": author or "&nbsp;",
         "TITLE": title,
+        "UPDATED": updated.strftime("%Y-%m-%d"),
         "PREVIEW_URL": preview_url,
         "RELEASE_URL": release_url,
     }

--- a/.github/template/item.template.html
+++ b/.github/template/item.template.html
@@ -3,5 +3,6 @@
 <a href="$RELEASE_URL">
 <img title="$TITLE" width="480px" src="$PREVIEW_URL" /><br/>
 <b>$NAME</b></a><br/>
-<sup><i>$AUTHOR</i></sup>
+<sub><i>$AUTHOR</i></sub><br>
+<sup><i>Updated: $UPDATED</i></sup>
 </td>

--- a/README.md
+++ b/README.md
@@ -79,21 +79,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/CyberOnion%20by%20Aemiii91.zip?raw=true">
 <img title="CyberOnion by Aemiii91" width="480px" src="themes/CyberOnion%20by%20Aemiii91/preview.png?raw=true" /><br/>
 <b>CyberOnion</b></a><br/>
-<sup><i>Aemiii91</i></sup>
+<sub><i>Aemiii91</i></sub><br>
+<sup><i>Updated: 2022-10-05</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Tema%20by%20Alex%20Connor.zip?raw=true">
 <img title="Tema by Alex Connor" width="480px" src="themes/Tema%20by%20Alex%20Connor/preview.png?raw=true" /><br/>
 <b>Tema</b></a><br/>
-<sup><i>Alex Connor</i></sup>
+<sub><i>Alex Connor</i></sub><br>
+<sup><i>Updated: 2022-10-02</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Onion%20Boy%20DX%20by%20PixelShift.zip?raw=true">
 <img title="Onion Boy DX by PixelShift" width="480px" src="themes/Onion%20Boy%20DX%20by%20PixelShift/preview.png?raw=true" /><br/>
 <b>Onion Boy DX</b></a><br/>
-<sup><i>PixelShift</i></sup>
+<sub><i>PixelShift</i></sub><br>
+<sup><i>Updated: 2022-10-03</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -101,21 +104,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Onion%20Boy%20by%20PixelShift%20%2B%20Jeltron.zip?raw=true">
 <img title="Onion Boy by PixelShift + Jeltron" width="480px" src="themes/Onion%20Boy%20by%20PixelShift%20%2B%20Jeltron/preview.png?raw=true" /><br/>
 <b>Onion Boy</b></a><br/>
-<sup><i>PixelShift + Jeltron</i></sup>
+<sub><i>PixelShift + Jeltron</i></sub><br>
+<sup><i>Updated: 2022-10-03</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/MiNook%20Mini%20by%20Deepslackerjazz.zip?raw=true">
 <img title="Nook phone type theme with a crafty vibe" width="480px" src="themes/MiNook%20Mini%20by%20Deepslackerjazz/preview.png?raw=true" /><br/>
 <b>MiNook</b></a><br/>
-<sup><i>Deepslackerjazz</i></sup>
+<sub><i>Deepslackerjazz</i></sub><br>
+<sup><i>Updated: 2022-09-19</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/less%20by%20junk.zip?raw=true">
 <img title="Another minimalist theme" width="480px" src="themes/less%20by%20junk/preview.png?raw=true" /><br/>
 <b>less</b></a><br/>
-<sup><i>junk</i></sup>
+<sub><i>junk</i></sub><br>
+<sup><i>Updated: 2022-09-17</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -123,21 +129,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/RPO%20by%20TheDewd.zip?raw=true">
 <img title="Pixel Art Fantasy Theme" width="480px" src="themes/RPO%20by%20TheDewd/preview.png?raw=true" /><br/>
 <b>Role Playing Onion</b></a><br/>
-<sup><i>TheDewd</i></sup>
+<sub><i>TheDewd</i></sub><br>
+<sup><i>Updated: 2022-09-17</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/BRCKD%20by%20Deepslackerjazz.zip?raw=true">
 <img title="BRCKD by Deepslackerjazz" width="480px" src="themes/BRCKD%20by%20Deepslackerjazz/preview.png?raw=true" /><br/>
 <b>BRCKD</b></a><br/>
-<sup><i>Deepslackerjazz</i></sup>
+<sub><i>Deepslackerjazz</i></sub><br>
+<sup><i>Updated: 2022-09-11</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Onionboy%20HD%20by%20Jeltron.zip?raw=true">
 <img title="Higher res variant of OnionBoy" width="480px" src="themes/Onionboy%20HD%20by%20Jeltron/preview.png?raw=true" /><br/>
 <b>Onionboy HD</b></a><br/>
-<sup><i>Jeltron</i></sup>
+<sub><i>Jeltron</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -145,21 +154,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/End%20of%20Ages%20by%20apg313.zip?raw=true">
 <img title="End of Ages by apg313" width="480px" src="themes/End%20of%20Ages%20by%20apg313/preview.png?raw=true" /><br/>
 <b>End of Ages</b></a><br/>
-<sup><i>apg313</i></sup>
+<sub><i>apg313</i></sub><br>
+<sup><i>Updated: 2022-08-16</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/System%209%20by%20injekim.zip?raw=true">
 <img title="System 9 by injekim" width="480px" src="themes/System%209%20by%20injekim/preview.png?raw=true" /><br/>
 <b>System 9</b></a><br/>
-<sup><i>injekim</i></sup>
+<sub><i>injekim</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/gry64%20by%20iamatrap.zip?raw=true">
 <img title="GRY64 by iamatrap" width="480px" src="themes/gry64%20by%20iamatrap/preview.png?raw=true" /><br/>
 <b>GRY64</b></a><br/>
-<sup><i>iamatrap</i></sup>
+<sub><i>iamatrap</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -167,21 +179,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Shadaloo%20%28SFA3%29%20by%20XCVNCE.zip?raw=true">
 <img title="Shadaloo (SFA3) by XCVNCE" width="480px" src="themes/Shadaloo%20%28SFA3%29%20by%20XCVNCE/preview.png?raw=true" /><br/>
 <b>Shadaloo (SFA3)</b></a><br/>
-<sup><i>XCVNCE</i></sup>
+<sub><i>XCVNCE</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/BMO%20by%20OjninJo.zip?raw=true">
 <img title="Who wants to play videogames!?" width="480px" src="themes/BMO%20by%20OjninJo/preview.png?raw=true" /><br/>
 <b>BMO</b></a><br/>
-<sup><i>OjninJo</i></sup>
+<sub><i>OjninJo</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/MasterHacker%20by%20Squ1d0ne.zip?raw=true">
 <img title="MasterHacker by Squ1d0ne" width="480px" src="themes/MasterHacker%20by%20Squ1d0ne/preview.png?raw=true" /><br/>
 <b>MasterHacker</b></a><br/>
-<sup><i>Squ1d0ne</i></sup>
+<sub><i>Squ1d0ne</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -189,21 +204,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Analogue%20by%20Aemiii91.zip?raw=true">
 <img title="Minimalist theme inspired by Analogue OS" width="480px" src="themes/Analogue%20by%20Aemiii91/preview.png?raw=true" /><br/>
 <b>Analogue</b></a><br/>
-<sup><i>Aemiii91</i></sup>
+<sub><i>Aemiii91</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/TrimUI%20by%20Aemiii91.zip?raw=true">
 <img title="TrimUI theme port" width="480px" src="themes/TrimUI%20by%20Aemiii91/preview.png?raw=true" /><br/>
 <b>TrimUI</b></a><br/>
-<sup><i>Aemiii91</i></sup>
+<sub><i>Aemiii91</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Blueprint%20by%20Aemiii91.zip?raw=true">
 <img title="Theme layout with 10x10 grid" width="480px" src="themes/Blueprint%20by%20Aemiii91/preview.png?raw=true" /><br/>
 <b>Blueprint</b></a><br/>
-<sup><i>Aemiii91</i></sup>
+<sub><i>Aemiii91</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -211,21 +229,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/3DS%20mini%20by%20MarsTaco.zip?raw=true">
 <img title="3DS inspired theme for Miyoo Mini" width="480px" src="themes/3DS%20mini%20by%20MarsTaco/preview.png?raw=true" /><br/>
 <b>3DS mini</b></a><br/>
-<sup><i>MarsTaco</i></sup>
+<sub><i>MarsTaco</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/MajoraMi%20by%20apg313.zip?raw=true">
 <img title="MajoraMi by apg313" width="480px" src="themes/MajoraMi%20by%20apg313/preview.png?raw=true" /><br/>
 <b>MajoraMi</b></a><br/>
-<sup><i>apg313</i></sup>
+<sub><i>apg313</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/GBC%20Pokedex%20by%20Nxt.stop.please.zip?raw=true">
 <img title="GBC Pokedex by Nxt.stop.please" width="480px" src="themes/GBC%20Pokedex%20by%20Nxt.stop.please/preview.png?raw=true" /><br/>
 <b>GBC Pokedex</b></a><br/>
-<sup><i>Nxt.stop.please</i></sup>
+<sub><i>Nxt.stop.please</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -233,21 +254,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Zenburn%20by%20duckbeets.zip?raw=true">
 <img title="Zenburn by duckbeets" width="480px" src="themes/Zenburn%20by%20duckbeets/preview.png?raw=true" /><br/>
 <b>Zenburn</b></a><br/>
-<sup><i>duckbeets</i></sup>
+<sub><i>duckbeets</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/ChronoMi%20by%20apg313.zip?raw=true">
 <img title="ChronoMi by apg313" width="480px" src="themes/ChronoMi%20by%20apg313/preview.png?raw=true" /><br/>
 <b>ChronoMi</b></a><br/>
-<sup><i>apg313</i></sup>
+<sub><i>apg313</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/GBMini%20by%20Kitsuvi.zip?raw=true">
 <img title="GBMini by Kitsuvi" width="480px" src="themes/GBMini%20by%20Kitsuvi/preview.png?raw=true" /><br/>
 <b>GBMini</b></a><br/>
-<sup><i>Kitsuvi</i></sup>
+<sub><i>Kitsuvi</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -255,21 +279,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/GBOnion%20by%20Kitsuvi.zip?raw=true">
 <img title="GBOnion by Kitsuvi" width="480px" src="themes/GBOnion%20by%20Kitsuvi/preview.png?raw=true" /><br/>
 <b>GBOnion</b></a><br/>
-<sup><i>Kitsuvi</i></sup>
+<sub><i>Kitsuvi</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Hyrule%20Dark%20by%20ruidacosta.zip?raw=true">
 <img title="Hyrule Dark by ruidacosta" width="480px" src="themes/Hyrule%20Dark%20by%20ruidacosta/preview.png?raw=true" /><br/>
 <b>Hyrule Dark</b></a><br/>
-<sup><i>ruidacosta</i></sup>
+<sub><i>ruidacosta</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/EVA%20by%20laumser7%20%2B%20trere.zip?raw=true">
 <img title="EVA by laumser7 + trere" width="480px" src="themes/EVA%20by%20laumser7%20%2B%20trere/preview.png?raw=true" /><br/>
 <b>EVA</b></a><br/>
-<sup><i>laumser7 + trere</i></sup>
+<sub><i>laumser7 + trere</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -277,21 +304,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Animiyoo%20by%20laumser7.zip?raw=true">
 <img title="Animiyoo by laumser7" width="480px" src="themes/Animiyoo%20by%20laumser7/preview.png?raw=true" /><br/>
 <b>Animiyoo</b></a><br/>
-<sup><i>laumser7</i></sup>
+<sub><i>laumser7</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Super%20Onion%20Entertainment%20System%20by%20TheDewd.zip?raw=true">
 <img title="Super Onion Entertainment System by TheDewd" width="480px" src="themes/Super%20Onion%20Entertainment%20System%20by%20TheDewd/preview.png?raw=true" /><br/>
 <b>Super Onion Entertainment System</b></a><br/>
-<sup><i>TheDewd</i></sup>
+<sub><i>TheDewd</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/PSPmini%20Blue%20by%20MarsTaco.zip?raw=true">
 <img title="PSPmini Blue by MarsTaco" width="480px" src="themes/PSPmini%20Blue%20by%20MarsTaco/PSPmini%20Blue%20%28Clean%20View%29%20by%20MarsTaco/preview.png?raw=true" /><br/>
 <b>PSPmini Blue</b></a><br/>
-<sup><i>MarsTaco</i></sup>
+<sub><i>MarsTaco</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -299,21 +329,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/PSPmini%20by%20MarsTaco.zip?raw=true">
 <img title="PSPmini by MarsTaco" width="480px" src="themes/PSPmini%20by%20MarsTaco/PSPmini%20%28Clean%20View%29%20by%20MarsTaco/preview.png?raw=true" /><br/>
 <b>PSPmini</b></a><br/>
-<sup><i>MarsTaco</i></sup>
+<sub><i>MarsTaco</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Hippo%20Stock.zip?raw=true">
 <img title="Hippo Stock" width="480px" src="themes/Hippo%20Stock/preview.png?raw=true" /><br/>
 <b>Hippo Stock</b></a><br/>
-<sup><i>&nbsp;</i></sup>
+<sub><i>&nbsp;</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/MakoVII%20by%20Gloomy_Background755.zip?raw=true">
 <img title="MakoVII by Gloomy_Background755" width="480px" src="themes/MakoVII%20by%20Gloomy_Background755/preview.png?raw=true" /><br/>
 <b>MakoVII</b></a><br/>
-<sup><i>Gloomy_Background755</i></sup>
+<sub><i>Gloomy_Background755</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -321,21 +354,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Plastic%20Leaf%20%28NA%29%20by%20leafflat.zip?raw=true">
 <img title="Plastic Leaf (NA) by leafflat" width="480px" src="themes/Plastic%20Leaf%20%28NA%29%20by%20leafflat/preview.png?raw=true" /><br/>
 <b>Plastic Leaf (NA)</b></a><br/>
-<sup><i>leafflat</i></sup>
+<sub><i>leafflat</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Plastic%20Leaf%20%28EU%29%20by%20leafflat.zip?raw=true">
 <img title="Plastic Leaf (EU) by leafflat" width="480px" src="themes/Plastic%20Leaf%20%28EU%29%20by%20leafflat/preview.png?raw=true" /><br/>
 <b>Plastic Leaf (EU)</b></a><br/>
-<sup><i>leafflat</i></sup>
+<sub><i>leafflat</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/National%20Pokedex%20by%20Vanta_black.zip?raw=true">
 <img title="National Pokedex by Vanta_black" width="480px" src="themes/National%20Pokedex%20by%20Vanta_black/preview.png?raw=true" /><br/>
 <b>National Pokedex</b></a><br/>
-<sup><i>Vanta_black</i></sup>
+<sub><i>Vanta_black</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -343,21 +379,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/GameMaster.zip?raw=true">
 <img title="GameMaster" width="480px" src="themes/GameMaster/preview.png?raw=true" /><br/>
 <b>GameMaster</b></a><br/>
-<sup><i>&nbsp;</i></sup>
+<sub><i>&nbsp;</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Miyoo%20blues.zip?raw=true">
 <img title="Miyoo blues" width="480px" src="themes/Miyoo%20blues/preview.png?raw=true" /><br/>
 <b>Miyoo blues</b></a><br/>
-<sup><i>&nbsp;</i></sup>
+<sub><i>&nbsp;</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Miyoo%20jazz.zip?raw=true">
 <img title="Miyoo jazz" width="480px" src="themes/Miyoo%20jazz/preview.png?raw=true" /><br/>
 <b>Miyoo jazz</b></a><br/>
-<sup><i>&nbsp;</i></sup>
+<sub><i>&nbsp;</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -365,21 +404,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Monster%20Hunter%20by%20Miyoo.zip?raw=true">
 <img title="Monster Hunter by Miyoo" width="480px" src="themes/Monster%20Hunter%20by%20Miyoo/preview.png?raw=true" /><br/>
 <b>Monster Hunter</b></a><br/>
-<sup><i>Miyoo</i></sup>
+<sub><i>Miyoo</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Aubergine%20by%20blueasis.zip?raw=true">
 <img title="Aubergine by blueasis" width="480px" src="themes/Aubergine%20by%20blueasis/preview.png?raw=true" /><br/>
 <b>Aubergine</b></a><br/>
-<sup><i>blueasis</i></sup>
+<sub><i>blueasis</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Codec%20by%20ScarGutz.zip?raw=true">
 <img title="Codec by ScarGutz" width="480px" src="themes/Codec%20by%20ScarGutz/preview.png?raw=true" /><br/>
 <b>Codec</b></a><br/>
-<sup><i>ScarGutz</i></sup>
+<sub><i>ScarGutz</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -387,21 +429,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Black%20Cotton%20Candy%20by%20PixelShift.zip?raw=true">
 <img title="Black Cotton Candy by PixelShift" width="480px" src="themes/Black%20Cotton%20Candy%20by%20PixelShift/preview.png?raw=true" /><br/>
 <b>Black Cotton Candy</b></a><br/>
-<sup><i>PixelShift</i></sup>
+<sub><i>PixelShift</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Business%20by%20Jim%20Gray.zip?raw=true">
 <img title="Business by Jim Gray" width="480px" src="themes/Business%20by%20Jim%20Gray/preview.png?raw=true" /><br/>
 <b>Business</b></a><br/>
-<sup><i>Jim Gray</i></sup>
+<sub><i>Jim Gray</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Fuzzy%20Pickles%21%20by%20Updog.zip?raw=true">
 <img title="Fuzzy Pickles! by Updog" width="480px" src="themes/Fuzzy%20Pickles%21%20by%20Updog/preview.png?raw=true" /><br/>
 <b>Fuzzy Pickles!</b></a><br/>
-<sup><i>Updog</i></sup>
+<sub><i>Updog</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -409,21 +454,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Galaxy%20by%20PixelShift.zip?raw=true">
 <img title="Galaxy by PixelShift" width="480px" src="themes/Galaxy%20by%20PixelShift/preview.png?raw=true" /><br/>
 <b>Galaxy</b></a><br/>
-<sup><i>PixelShift</i></sup>
+<sub><i>PixelShift</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Miyoo%20Quest%20by%20y_oshid_a.zip?raw=true">
 <img title="Miyoo Quest by y_oshid_a" width="480px" src="themes/Miyoo%20Quest%20by%20y_oshid_a/preview.png?raw=true" /><br/>
 <b>Miyoo Quest</b></a><br/>
-<sup><i>y_oshid_a</i></sup>
+<sub><i>y_oshid_a</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Lilla%20by%20evolve.zip?raw=true">
 <img title="Lilla by evolve" width="480px" src="themes/Lilla%20by%20evolve/preview.png?raw=true" /><br/>
 <b>Lilla</b></a><br/>
-<sup><i>evolve</i></sup>
+<sub><i>evolve</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -431,21 +479,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Oransje%20by%20evolve.zip?raw=true">
 <img title="Oransje by evolve" width="480px" src="themes/Oransje%20by%20evolve/preview.png?raw=true" /><br/>
 <b>Oransje</b></a><br/>
-<sup><i>evolve</i></sup>
+<sub><i>evolve</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Onichan%20by%20PixelShift.zip?raw=true">
 <img title="Onichan by PixelShift" width="480px" src="themes/Onichan%20by%20PixelShift/preview.png?raw=true" /><br/>
 <b>Onichan</b></a><br/>
-<sup><i>PixelShift</i></sup>
+<sub><i>PixelShift</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Onion%20Mini%20by%20Jeltron.zip?raw=true">
 <img title="Onion Mini by Jeltron" width="480px" src="themes/Onion%20Mini%20by%20Jeltron/preview.png?raw=true" /><br/>
 <b>Onion Mini</b></a><br/>
-<sup><i>Jeltron</i></sup>
+<sub><i>Jeltron</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -453,21 +504,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Onyan%20by%20PixelShift.zip?raw=true">
 <img title="Onyan by PixelShift" width="480px" src="themes/Onyan%20by%20PixelShift/preview.png?raw=true" /><br/>
 <b>Onyan</b></a><br/>
-<sup><i>PixelShift</i></sup>
+<sub><i>PixelShift</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Poketch%20by%20Lucario.zip?raw=true">
 <img title="Pokétch by Lucario" width="480px" src="themes/Poketch%20by%20Lucario/preview.png?raw=true" /><br/>
 <b>Pokétch</b></a><br/>
-<sup><i>Lucario</i></sup>
+<sub><i>Lucario</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/2022%20Stock%20by%20Miyoo.zip?raw=true">
 <img title="2022 Stock by Miyoo" width="480px" src="themes/2022%20Stock%20by%20Miyoo/preview.png?raw=true" /><br/>
 <b>2022 Stock</b></a><br/>
-<sup><i>Miyoo</i></sup>
+<sub><i>Miyoo</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -475,21 +529,24 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/2021%20Stock%20by%20Miyoo.zip?raw=true">
 <img title="2021 Stock by Miyoo" width="480px" src="themes/2021%20Stock%20by%20Miyoo/preview.png?raw=true" /><br/>
 <b>2021 Stock</b></a><br/>
-<sup><i>Miyoo</i></sup>
+<sub><i>Miyoo</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Switch%20by%20PixelShift.zip?raw=true">
 <img title="Switch by PixelShift" width="480px" src="themes/Switch%20by%20PixelShift/preview.png?raw=true" /><br/>
 <b>Switch</b></a><br/>
-<sup><i>PixelShift</i></sup>
+<sub><i>PixelShift</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Synthwave%20by%20Ritual.zip?raw=true">
 <img title="Synthwave by Ritual" width="480px" src="themes/Synthwave%20by%20Ritual/preview.png?raw=true" /><br/>
 <b>Synthwave</b></a><br/>
-<sup><i>Ritual</i></sup>
+<sub><i>Ritual</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -497,14 +554,16 @@ Do you want to share your own custom themes with the community? <sup><sub>❤️
 <a href="release/Wavedash%20by%20historymaker118.zip?raw=true">
 <img title="Wavedash by historymaker118" width="480px" src="themes/Wavedash%20by%20historymaker118/preview.png?raw=true" /><br/>
 <b>Wavedash</b></a><br/>
-<sup><i>historymaker118</i></sup>
+<sub><i>historymaker118</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/BirdShot%20by%20historymaker118.zip?raw=true">
 <img title="BirdShot by historymaker118" width="480px" src="themes/BirdShot%20by%20historymaker118/preview.png?raw=true" /><br/>
 <b>BirdShot</b></a><br/>
-<sup><i>historymaker118</i></sup>
+<sub><i>historymaker118</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 
 </tr></table>
@@ -524,21 +583,24 @@ This section showcases theme remixes made by the community and approved by the o
 <a href="release/Zenburn%201.5%20by%20duckbeets%20%2B%20Catz.zip?raw=true">
 <img title="Zenburn 1.5 by duckbeets + Catz" width="480px" src="themes/Zenburn%201.5%20by%20duckbeets%20%2B%20Catz/preview.png?raw=true" /><br/>
 <b>Zenburn 1.5</b></a><br/>
-<sup><i>duckbeets + Catz</i></sup>
+<sub><i>duckbeets + Catz</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/GBOnion%20Dark%20by%20Kitsuvi%20%2B%20andresandiah.zip?raw=true">
 <img title="Recolor by andresandiah" width="480px" src="themes/GBOnion%20Dark%20by%20Kitsuvi%20%2B%20andresandiah/preview.png?raw=true" /><br/>
 <b>GBOnion Dark</b></a><br/>
-<sup><i>Kitsuvi + andresandiah</i></sup>
+<sub><i>Kitsuvi + andresandiah</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Red%20Onion%20by%20PixelShift%20%2B%20Jeltron%20%2B%20Moontorc.zip?raw=true">
 <img title="Recolor by Moontorc" width="480px" src="themes/Red%20Onion%20by%20PixelShift%20%2B%20Jeltron%20%2B%20Moontorc/preview.png?raw=true" /><br/>
 <b>Red Onion</b></a><br/>
-<sup><i>PixelShift + Jeltron + Moontorc</i></sup>
+<sub><i>PixelShift + Jeltron + Moontorc</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -546,21 +608,24 @@ This section showcases theme remixes made by the community and approved by the o
 <a href="release/Onionboy%20HD%20Gray%20by%20Jeltron%20%2B%20TechDevangelist.zip?raw=true">
 <img title="Recolor by TechDevangelist" width="480px" src="themes/Onionboy%20HD%20Gray%20by%20Jeltron%20%2B%20TechDevangelist/preview.png?raw=true" /><br/>
 <b>Onionboy HD Gray</b></a><br/>
-<sup><i>Jeltron + TechDevangelist</i></sup>
+<sub><i>Jeltron + TechDevangelist</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Onion%20Boy%20Pocket%20by%20PixelShift%20%2B%20H9K.zip?raw=true">
 <img title="Recolor by H9L" width="480px" src="themes/Onion%20Boy%20Pocket%20by%20PixelShift%20%2B%20H9K/preview.png?raw=true" /><br/>
 <b>Onion Boy Pocket</b></a><br/>
-<sup><i>PixelShift + H9L</i></sup>
+<sub><i>PixelShift + H9L</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Onion%20Boy%20Dark%20by%20PixelShift.zip?raw=true">
 <img title="Contrast edit by PixelShift" width="480px" src="themes/Onion%20Boy%20Dark%20by%20PixelShift/preview.png?raw=true" /><br/>
 <b>Onion Boy Dark</b></a><br/>
-<sup><i>PixelShift</i></sup>
+<sub><i>PixelShift</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 
 </tr></table>
@@ -578,21 +643,24 @@ This section showcases the themes included with Onion.
 <a href="release/Silky%20by%20DiMo.zip?raw=true">
 <img title="[Onion default theme]" width="480px" src="themes/Silky%20by%20DiMo/preview.png?raw=true" /><br/>
 <b>Silky</b></a><br/>
-<sup><i>DiMo</i></sup>
+<sub><i>DiMo</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Analogue%20by%20Aemiii91.zip?raw=true">
 <img title="Minimalist theme inspired by Analogue OS" width="480px" src="themes/Analogue%20by%20Aemiii91/preview.png?raw=true" /><br/>
 <b>Analogue</b></a><br/>
-<sup><i>Aemiii91</i></sup>
+<sub><i>Aemiii91</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Onionboy%20HD%20by%20Jeltron.zip?raw=true">
 <img title="Higher res variant of OnionBoy" width="480px" src="themes/Onionboy%20HD%20by%20Jeltron/preview.png?raw=true" /><br/>
 <b>Onionboy HD</b></a><br/>
-<sup><i>Jeltron</i></sup>
+<sub><i>Jeltron</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -600,21 +668,24 @@ This section showcases the themes included with Onion.
 <a href="release/System%209%20by%20injekim.zip?raw=true">
 <img title="System 9 by injekim" width="480px" src="themes/System%209%20by%20injekim/preview.png?raw=true" /><br/>
 <b>System 9</b></a><br/>
-<sup><i>injekim</i></sup>
+<sub><i>injekim</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/GBMini%20by%20Kitsuvi.zip?raw=true">
 <img title="GBMini by Kitsuvi" width="480px" src="themes/GBMini%20by%20Kitsuvi/preview.png?raw=true" /><br/>
 <b>GBMini</b></a><br/>
-<sup><i>Kitsuvi</i></sup>
+<sub><i>Kitsuvi</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Switch%20by%20PixelShift.zip?raw=true">
 <img title="Switch by PixelShift" width="480px" src="themes/Switch%20by%20PixelShift/preview.png?raw=true" /><br/>
 <b>Switch</b></a><br/>
-<sup><i>PixelShift</i></sup>
+<sub><i>PixelShift</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -622,21 +693,24 @@ This section showcases the themes included with Onion.
 <a href="release/Onion%20Boy%20by%20PixelShift%20%2B%20Jeltron.zip?raw=true">
 <img title="Onion Boy by PixelShift + Jeltron" width="480px" src="themes/Onion%20Boy%20by%20PixelShift%20%2B%20Jeltron/preview.png?raw=true" /><br/>
 <b>Onion Boy</b></a><br/>
-<sup><i>PixelShift + Jeltron</i></sup>
+<sub><i>PixelShift + Jeltron</i></sub><br>
+<sup><i>Updated: 2022-10-03</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Miyoo%20blues.zip?raw=true">
 <img title="Miyoo blues" width="480px" src="themes/Miyoo%20blues/preview.png?raw=true" /><br/>
 <b>Miyoo blues</b></a><br/>
-<sup><i>&nbsp;</i></sup>
+<sub><i>&nbsp;</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Miyoo%20jazz.zip?raw=true">
 <img title="Miyoo jazz" width="480px" src="themes/Miyoo%20jazz/preview.png?raw=true" /><br/>
 <b>Miyoo jazz</b></a><br/>
-<sup><i>&nbsp;</i></sup>
+<sub><i>&nbsp;</i></sub><br>
+<sup><i>Updated: 2022-08-07</i></sup>
 </td>
 </tr><tr>
 <td align="center" valign="top">
@@ -644,14 +718,16 @@ This section showcases the themes included with Onion.
 <a href="release/Lilla%20by%20evolve.zip?raw=true">
 <img title="Lilla by evolve" width="480px" src="themes/Lilla%20by%20evolve/preview.png?raw=true" /><br/>
 <b>Lilla</b></a><br/>
-<sup><i>evolve</i></sup>
+<sub><i>evolve</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 <td align="center" valign="top">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br/>
 <a href="release/Hippo%20Stock.zip?raw=true">
 <img title="Hippo Stock" width="480px" src="themes/Hippo%20Stock/preview.png?raw=true" /><br/>
 <b>Hippo Stock</b></a><br/>
-<sup><i>&nbsp;</i></sup>
+<sub><i>&nbsp;</i></sub><br>
+<sup><i>Updated: 2022-09-09</i></sup>
 </td>
 
 </tr></table>


### PR DESCRIPTION
Someone mentioned [in Discord](https://discord.com/channels/529983248114122762/891336865540620338/1026925571034320906) that they'd be interested to know when themes are updated, so this adds a very basic display of the date each theme was updated.

I was playing around with a custom format, but because Python doesn't have any great date parsing built-in, I settled for just taking the year, month, and day from what git outputs.

You can see a preview [here](https://github.com/belak/OnionUI-Themes/tree/readme-experiment#custom-themes)