### PR TITLE
Update config.json for better battery readability in Beneath the Mask

### DIFF
--- a/themes/Beneath The Mask by UnBurn/config.json
+++ b/themes/Beneath The Mask by UnBurn/config.json
@@ -10,7 +10,7 @@
         "visible": false,
         "font": "OptimaNovaLT-Black.ttf",
         "size": 25,
-        "color": "#FFFFFF",
+        "color": "#FF0505",
         "offsetX": 0,
         "offsetY": 0,
         "onleft": false


### PR DESCRIPTION
The color of the battery percentage is white by default, which makes it unreadable against the background. This small change makes the battery percentage text red to counter that.